### PR TITLE
Add .env token support for bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@ This repository contains a simple EchoBot implemented in Python.
 
 ## Usage
 
-Run the bot from the command line:
+Create a `.env` file with your token:
+
+```bash
+echo "BOT_TOKEN=your-token" > .env
+```
+
+Then run the bot from the command line:
 
 ```bash
 python -m bot.main
 ```
 
+The bot will automatically load `BOT_TOKEN` from the `.env` file if it exists.
 Then enter messages. Type `quit` or press `Ctrl+D` to exit.

--- a/bot/echo_bot.py
+++ b/bot/echo_bot.py
@@ -1,16 +1,21 @@
 """Simple echo bot implementation."""
 
 from dataclasses import dataclass
+from typing import Optional
 
 @dataclass
 class EchoBot:
     """A basic bot that echoes messages."""
 
     name: str = "EchoBot"
+    token: Optional[str] = None
 
     def greet(self) -> str:
         """Return a greeting message."""
-        return f"Hello, I am {self.name}!"
+        greeting = f"Hello, I am {self.name}!"
+        if self.token:
+            greeting += " (token loaded)"
+        return greeting
 
     def respond(self, message: str) -> str:
         """Respond by echoing the received message."""

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,11 +1,29 @@
 """Command line interface for the EchoBot."""
 
+import os
+
 from .echo_bot import EchoBot
+
+
+def load_env(path: str = ".env") -> None:
+    """Load environment variables from a .env file if it exists."""
+    try:
+        with open(path) as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                os.environ.setdefault(key, value)
+    except FileNotFoundError:
+        pass
 
 
 def main() -> None:
     """Run a simple interaction loop with the EchoBot."""
-    bot = EchoBot()
+    load_env()
+    token = os.environ.get("BOT_TOKEN")
+    bot = EchoBot(token=token)
     print(bot.greet())
     while True:
         try:


### PR DESCRIPTION
## Summary
- allow the bot to load `BOT_TOKEN` from a `.env` file
- show token loading message when present
- document the `.env` token setup and ignore the file

## Testing
- `pytest -q`
- `python -m py_compile bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6852968801b4832c9aaa5bfe1d66cdd9