### PR TITLE
Implement Discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,24 @@ Create a `.env` file with your token:
 echo "BOT_TOKEN=your-token" > .env
 ```
 
-Then run the bot from the command line:
+Then run the echo bot from the command line:
 
 ```bash
 python -m bot.main
+```
+
+### Discord mode
+
+To run a real Discord bot you need the ``discord.py`` package installed:
+
+```bash
+pip install discord.py
+```
+
+Start the bot with:
+
+```bash
+python -m bot.discord_bot
 ```
 
 You can also run a standalone script that does not rely on the `bot` package:

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -1,0 +1,33 @@
+import os
+
+import discord
+
+from .main import load_env
+
+
+def main() -> None:
+    """Run the Discord echo bot."""
+    load_env()
+    token = os.environ.get("BOT_TOKEN")
+    if not token:
+        raise RuntimeError("BOT_TOKEN not set")
+
+    intents = discord.Intents.default()
+    client = discord.Client(intents=intents)
+
+    @client.event
+    async def on_ready():
+        print(f"Logged in as {client.user} (ID: {client.user.id})")
+        print("------")
+
+    @client.event
+    async def on_message(message: discord.Message):
+        if message.author == client.user:
+            return
+        await message.channel.send(f"You said: {message.content}")
+
+    client.run(token)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Discord-based bot implementation in `bot/discord_bot.py`
- document how to run the new Discord bot in the README

## Testing
- `python -m bot.discord_bot` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_68529c8595f4832caf5be2ed32fbc0fb