### PR TITLE
Fix env token loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository provides a minimal Discord bot implemented in Python.
 
 ## Setup
 
-1. Install the `discord.py` package:
+1. Install the `discord.py` and `python-dotenv` packages:
 
 ```bash
-pip install discord.py
+pip install discord.py python-dotenv
 ```
 
 2. Set the bot token in the `BOT_TOKEN` environment variable or create a `.env` file:
@@ -15,6 +15,8 @@ pip install discord.py
 ```bash
 echo "BOT_TOKEN=your-token" > .env
 ```
+
+The bot automatically loads the `.env` file from the repository directory when it runs.
 
 ## Running the Bot
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -1,9 +1,13 @@
 import os
+from pathlib import Path
+
 import discord
+from dotenv import load_dotenv
 
 
 def main() -> None:
     """Run the Discord bot."""
+    load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
     token = os.getenv("BOT_TOKEN")
     if not token:
         raise RuntimeError("BOT_TOKEN not set")


### PR DESCRIPTION
## Summary
- load `.env` in `discord_bot.py`
- document python-dotenv setup and automatic `.env` loading

## Testing
- `python -m py_compile discord_bot.py`
- `pip install python-dotenv` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6852a5392cac832ca56aa5588c334c7f