### PR TITLE
Implement wrong code response

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ The bot registers a `/send_input` slash command on startup that allows you to
 submit a code via a Discord modal. You can also trigger the same action by
 sending `/send-input` as a regular message. The command is synced automatically
 whenever the bot starts.
+
+When you submit a code through the modal, the bot currently always responds
+with a friendly error message letting you know the code is incorrect. The
+message is only visible to the person who submitted the code.

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -45,7 +45,8 @@ def main() -> None:
 
             async def on_submit(self, interaction: discord.Interaction) -> None:
                 await interaction.response.send_message(
-                    f"Received code: `{self.code.value}`", ephemeral=True
+                    "\N{CROSS MARK} Wrong code. Please check and try again!",
+                    ephemeral=True,
                 )
 
         class CodeView(ui.View):


### PR DESCRIPTION
## Summary
- always reply with a wrong code message when a user submits the modal
- document the behaviour in the README

## Testing
- `python -m py_compile discord_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685582e41554832cb6ea7b876e1198e5