### PR TITLE
Make send_input slash command message public

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -70,7 +70,7 @@ def main() -> None:
     @tree.command(name="send_input", description="Display modal to submit a code")
     async def send_input_command(interaction: discord.Interaction) -> None:
         embed, view = build_embed_view()
-        await interaction.response.send_message(embed=embed, view=view, ephemeral=True)
+        await interaction.response.send_message(embed=embed, view=view, ephemeral=False)
 
     client.run(token)
 


### PR DESCRIPTION
## Summary
- update slash command to send public messages

## Testing
- `python -m py_compile discord_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685583a63278832c911357663db72d68