### PR TITLE
Fix missing modal title in Discord bot

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -41,6 +41,11 @@ def main() -> None:
         embed.set_footer(text="Let's keep moving!")
 
         class CodeModal(ui.Modal):
+            """Modal to collect a code from the user."""
+
+            def __init__(self) -> None:
+                super().__init__(title="Submit Code")
+
             code = ui.TextInput(label="Input Code", placeholder="Your code")
 
             async def on_submit(self, interaction: discord.Interaction) -> None:


### PR DESCRIPTION
## Summary
- ensure `ui.Modal` includes a title when opened by the bot

## Testing
- `python -m py_compile discord_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6855846d61f8832ca803be7ebca9066a