### PR TITLE
Add role update on valid code

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ submit a code via a Discord modal. You can also trigger the same action by
 sending `/send-input` as a regular message. The command is synced automatically
 whenever the bot starts.
 
-When you submit a code through the modal, the bot currently always responds
-with a friendly error message letting you know the code is incorrect. The
-message is only visible to the person who submitted the code.
+When you submit a code through the modal, the bot now validates the value if you
+have the role `1385199472094740561`. The only accepted code for this role is
+`377`. Submitting this code removes the `1385199472094740561` role from you and
+grants the `1385658290490576988` role. Any other code results in a friendly
+error message visible only to the person who submitted it.
 
-Only members with roles 1385641525341454337 or 1385199472094740561 can use the CODE SUBMIT button.
+Only members with roles `1385641525341454337` or `1385199472094740561` can use
+the CODE SUBMIT button.

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -52,6 +52,25 @@ def main() -> None:
             code = ui.TextInput(label="Input Code", placeholder="Your code")
 
             async def on_submit(self, interaction: discord.Interaction) -> None:
+                member = interaction.guild.get_member(interaction.user.id) if interaction.guild else None
+                has_special_role = False
+                if member is not None:
+                    has_special_role = any(role.id == 1385199472094740561 for role in member.roles)
+
+                code_value = str(self.code.value).strip()
+
+                if has_special_role and code_value == "377":
+                    remove_role = interaction.guild.get_role(1385199472094740561)
+                    add_role = interaction.guild.get_role(1385658290490576988)
+                    if remove_role and add_role:
+                        await member.remove_roles(remove_role, reason="Correct code submitted")
+                        await member.add_roles(add_role, reason="Correct code submitted")
+                    await interaction.response.send_message(
+                        "\N{WHITE HEAVY CHECK MARK} Code accepted! Your roles have been updated.",
+                        ephemeral=True,
+                    )
+                    return
+
                 await interaction.response.send_message(
                     "\N{CROSS MARK} Wrong code. Please check and try again!",
                     ephemeral=True,


### PR DESCRIPTION
## Summary
- validate code for role `1385199472094740561`
- if code `377` is submitted, replace the role with `1385658290490576988`
- document the new behaviour in the README

## Testing
- `python -m py_compile discord_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68558d528758832cae00cae3d54e3c0f