### PR TITLE
Update button permissions and command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Run the bot with:
 npm start
 ```
 
-The bot registers a `/send_input` slash command on startup that allows you to submit a code via a Discord modal. You can also trigger the same action by sending `/send-input` as a regular message. The command is synced automatically whenever the bot starts.
+Send `/send-input` in any channel to receive an embed containing the **CODE SUBMIT** button. Clicking the button opens a modal where you can enter your access code.
 
 When you submit a code through the modal, the bot validates the value if you have the role `1385199472094740561`. The only accepted code for this role is `377`. Submitting this code removes the `1385199472094740561` role from you and grants the `1385658290490576988` role. Any other code results in a friendly error message visible only to the person who submitted it.
 
-Only members with roles `1385641525341454337` or `1385199472094740561` can use the CODE SUBMIT button.
+Members with the role `1385663190096154684` are blacklisted from using the CODE SUBMIT button.


### PR DESCRIPTION
## Summary
- blacklist role `1385663190096154684` from using the CODE SUBMIT button
- drop the slash command and only respond to `/send-input` messages
- update README with new workflow and permission details

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685591cd99bc832caccaa671adde10f7