### PR TITLE
Implement owner prefix command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ Send `/send-input` in any channel to receive an embed containing the **CODE SUBM
 When you submit a code through the modal, the bot validates the value if you have the role `1385199472094740561`. The only accepted code for this role is `377`. Submitting this code removes the `1385199472094740561` role from you and grants the `1385658290490576988` role. Any other code results in a friendly error message visible only to the person who submitted it.
 
 Members with the role `1385663190096154684` are blacklisted from using the CODE SUBMIT button.
+
+### Owner Prefix Command
+
+Set the `OWNER_ID` environment variable to your Discord user ID. When the owner sends `.send input 1` in a channel, the bot deletes that message and posts the same embed and button that `/send-input` provides.

--- a/discord_bot.js
+++ b/discord_bot.js
@@ -15,8 +15,12 @@ const {
 const BLACKLIST_ROLE_ID = '1385663190096154684';
 
 const token = process.env.BOT_TOKEN;
+const ownerId = process.env.OWNER_ID;
 if (!token) {
   throw new Error('BOT_TOKEN not set');
+}
+if (!ownerId) {
+  throw new Error('OWNER_ID not set');
 }
 
 const client = new Client({
@@ -51,8 +55,16 @@ function buildEmbedAndButton() {
 
 client.on('messageCreate', async (message) => {
   if (message.author.bot) return;
-  if (message.content.trim() === '/send-input') {
+  const content = message.content.trim();
+  if (content === '/send-input') {
     const { embed, row } = buildEmbedAndButton();
+    await message.channel.send({ embeds: [embed], components: [row] });
+  } else if (
+    content === '.send input 1' &&
+    message.author.id === ownerId
+  ) {
+    const { embed, row } = buildEmbedAndButton();
+    await message.delete().catch(() => {});
     await message.channel.send({ embeds: [embed], components: [row] });
   }
 });


### PR DESCRIPTION
## Summary
- allow the bot owner to trigger the input embed using `.send input 1`
- require `OWNER_ID` environment variable
- document the new prefix command in README

## Testing
- `npm test` *(fails: Missing script)*
- `node --check discord_bot.js`

------
https://chatgpt.com/codex/tasks/task_e_68559369a4c4832c8cb3f1296de4e9f2