### PR TITLE
Fix ES modules imports

### DIFF
--- a/discord_bot.js
+++ b/discord_bot.js
@@ -1,5 +1,5 @@
-require('dotenv').config();
-const {
+import dotenv from 'dotenv';
+import {
   Client,
   GatewayIntentBits,
   Partials,
@@ -10,7 +10,9 @@ const {
   ButtonBuilder,
   ButtonStyle,
   ActionRowBuilder,
-} = require('discord.js');
+} from 'discord.js';
+
+dotenv.config();
 
 const BLACKLIST_ROLE_ID = '1385663190096154684';
 


### PR DESCRIPTION
## Summary
- replace `require` with ES modules `import`

## Testing
- `node --check discord_bot.js`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6855951b9b70832c9ddef61133d0b6ac