### PR TITLE
Add second stage code logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Send `/send-input` in any channel to receive an embed containing the **CODE SUBM
 
 When you submit a code through the modal, the bot validates the value if you have the role `1385199472094740561`. The only accepted code for this role is `377`. Submitting this code removes the `1385199472094740561` role from you and grants the `1385658290490576988` role. Any other code results in a friendly error message visible only to the person who submitted it.
 
+Members who now have the `1385658290490576988` role can continue by submitting either `FORES` or `FOREST`. Entering `FORES` prompts a message saying *Almost! You’re missing something…* followed three seconds later by *…and what completes every forest?*. Entering `FOREST` is the correct code and upgrades the user to the `1385658291018797156` role while removing `1385658290490576988`.
+
 Members with the role `1385663190096154684` are blacklisted from using the CODE SUBMIT button.
 
 ### Owner Prefix Command

--- a/discord_bot.js
+++ b/discord_bot.js
@@ -15,6 +15,9 @@ import {
 dotenv.config();
 
 const BLACKLIST_ROLE_ID = '1385663190096154684';
+const STAGE1_ROLE_ID = '1385199472094740561';
+const STAGE2_ROLE_ID = '1385658290490576988';
+const STAGE3_ROLE_ID = '1385658291018797156';
 
 const token = process.env.BOT_TOKEN;
 const ownerId = process.env.OWNER_ID;
@@ -104,11 +107,34 @@ client.on('interactionCreate', async (interaction) => {
     await interaction.showModal(modal);
   } else if (interaction.isModalSubmit() && interaction.customId === 'code_modal') {
     const member = interaction.member;
-    const hasSpecialRole = member.roles.cache.some((role) => role.id === '1385199472094740561');
     const codeValue = interaction.fields.getTextInputValue('code_input').trim();
-    if (hasSpecialRole && codeValue === '377') {
-      const removeRole = interaction.guild.roles.cache.get('1385199472094740561');
-      const addRole = interaction.guild.roles.cache.get('1385658290490576988');
+    const hasStage1 = member.roles.cache.some((role) => role.id === STAGE1_ROLE_ID);
+    const hasStage2 = member.roles.cache.some((role) => role.id === STAGE2_ROLE_ID);
+
+    if (hasStage1 && codeValue === '377') {
+      const removeRole = interaction.guild.roles.cache.get(STAGE1_ROLE_ID);
+      const addRole = interaction.guild.roles.cache.get(STAGE2_ROLE_ID);
+      if (removeRole && addRole) {
+        await member.roles.remove(removeRole, 'Correct code submitted');
+        await member.roles.add(addRole, 'Correct code submitted');
+      }
+      await interaction.reply({
+        content: '✅ Code accepted! Your roles have been updated.',
+        ephemeral: true,
+      });
+    } else if (hasStage2 && codeValue === 'FORES') {
+      await interaction.reply({
+        content: 'Almost! You\u2019re missing something\u2026',
+        ephemeral: true,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      await interaction.followUp({
+        content: '\u2026and what completes every forest?',
+        ephemeral: true,
+      });
+    } else if (hasStage2 && codeValue === 'FOREST') {
+      const removeRole = interaction.guild.roles.cache.get(STAGE2_ROLE_ID);
+      const addRole = interaction.guild.roles.cache.get(STAGE3_ROLE_ID);
       if (removeRole && addRole) {
         await member.roles.remove(removeRole, 'Correct code submitted');
         await member.roles.add(addRole, 'Correct code submitted');


### PR DESCRIPTION
## Summary
- allow `FORES` and `FOREST` codes for users with role `1385658290490576988`
- add transition role IDs and stage logic
- document new codes in README

## Testing
- `node --check discord_bot.js`

------
https://chatgpt.com/codex/tasks/task_e_6856a6cd4cc0832ca3eec9d4e3ab0081